### PR TITLE
Local menu button bug

### DIFF
--- a/Geocube/contrib/MHTabBarController/MHTabBarController.m
+++ b/Geocube/contrib/MHTabBarController/MHTabBarController.m
@@ -431,6 +431,15 @@ static const NSInteger TagOffset = 1000;
     UIButton *b = localMenuButton;
     UIImage *imgMenu = currentTheme.menuLocalIcon;
     b.frame = CGRectMake(bounds.size.width - 2 - imgMenu.size.width, self.tabBarHeight - imgMenu.size.height - 2, imgMenu.size.width, imgMenu.size.height);
+    
+    // XXX menuGlobal.menuLocalButton can get out of sync with localMenuButton.
+    // XXX I'm not sure why you even have multiple local menu buttons, but
+    // XXX you need to ensure that menuGlobal.menuLocalButton is set to the
+    // XXX appropriate one!
+    if (localMenuButton != menuGlobal.menuLocalButton) {
+        NSLog(@"Warning! menuGlobal doesn't have the same local menu button!");
+        menuGlobal.menuLocalButton = b;
+    }
 }
 
 - (void)resizeController:(CGSize)size coordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/Geocube/contrib/MHTabBarController/MHTabBarController.m
+++ b/Geocube/contrib/MHTabBarController/MHTabBarController.m
@@ -440,6 +440,9 @@ static const NSInteger TagOffset = 1000;
         NSLog(@"Warning! menuGlobal doesn't have the same local menu button!");
         menuGlobal.menuLocalButton = b;
     }
+    if (globalMenuButton != menuGlobal.menuGlobalButton) {
+        NSLog(@"XXX menuGlobal doesn't have the same global menu button");
+    }
 }
 
 - (void)resizeController:(CGSize)size coordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/Geocube/contrib/MHTabBarController/MHTabBarController.m
+++ b/Geocube/contrib/MHTabBarController/MHTabBarController.m
@@ -438,10 +438,11 @@ static const NSInteger TagOffset = 1000;
     // XXX appropriate one!
     if (localMenuButton != menuGlobal.menuLocalButton) {
         NSLog(@"Warning! menuGlobal doesn't have the same local menu button!");
-        menuGlobal.menuLocalButton = b;
+        menuGlobal.menuLocalButton = localMenuButton;
     }
     if (globalMenuButton != menuGlobal.menuGlobalButton) {
         NSLog(@"XXX menuGlobal doesn't have the same global menu button");
+        menuGlobal.menuGlobalButton = globalMenuButton;
     }
 }
 


### PR DESCRIPTION
There is a bug in Geocube where the local menu button isn't always hidden or shown when it is supposed to be. The problem is caused because viewWillAppear doesn't set menuGlobal.menuLocalButton to the appropriate localMenuButton, so sometimes the previous MHTabBarController's localMenuButton is being displayed (and so it doesn't get hidden).

You can see this bug if you switch between different tab bar controllers via the global menu and between the items within a tab bar controller which should show/hide the local menu button.

Here is one way to reproduce the problem:
1. Go to navigate/target.
2. Exit app (and kill) -- this just makes sure that you're in a known state when starting up.
3. Start up app
4. You'll be at navigate/compass (no local menu button)
5. Choose target tab (local menu button appears)
6. Use global menu to switch to help. You'll be on "About", with no local menu button
7. Choose Help tab (local menu button appears)
8. Use global menu to switch to navigate. You'll be on "Target" with a local menu button -- but I believe it's actually the local menu button from the Help tab controller, although visually you can't tell.
9. Choose compass tab. 
Local menu is still there.

The fix is easy: just set the globalMenu object's cached value appropriately when the view is displayed.

My code does that (as well as printing out a log message for you to see what is happening).