### PR TITLE
Fix bug where program crashes on import if correct authorization keys…

### DIFF
--- a/Geocube/Convertors/ImportGeocube.m
+++ b/Geocube/Convertors/ImportGeocube.m
@@ -310,6 +310,9 @@ typedef NS_ENUM(NSInteger, Type) {
         NSString *revision = [site objectForKey:@"revision"];
         NSString *_site = [site objectForKey:@"site"];
         NSString *enabled = [site objectForKey:@"enabled"];
+        BOOL enabledBool = NO;
+        if ([enabled isEqualToString:@"YES"] == YES)
+            enabledBool = YES;
 
         KEY(site, gca_authenticate_url, @"gca_authenticate_url");
         KEY(site, gca_callback_url, @"gca_callback_url");
@@ -323,10 +326,22 @@ typedef NS_ENUM(NSInteger, Type) {
         KEY(site, oauth_url_authorize, @"oauth_url_authorize");
         KEY(site, oauth_url_request, @"oauth_url_request");
 
-        if (oauth_key_private_ss != nil)
+        if (oauth_key_private_ss != nil) {
             oauth_key_private = [keyManager decrypt:oauth_key_private_ss data:oauth_key_private];
-        if (oauth_key_public_ss != nil)
+            if (oauth_key_private == nil) {
+                NSLog(@"Couldn't find oauth private key for %@. This means that EncryptionKeys.plist is missing data", oauth_key_private_ss);
+                // To keep the program from crashing, disable this account.
+                enabledBool = NO;
+            }
+        }
+        if (oauth_key_public_ss != nil) {
             oauth_key_public = [keyManager decrypt:oauth_key_public_ss data:oauth_key_public];
+            if (oauth_key_public == nil) {
+                NSLog(@"Couldn't find oauth public key for %@. This means that EncryptionKeys.plist is missing data", oauth_key_public_ss);
+                // To keep the program from crashing, disable this account.
+                enabledBool = NO;
+            }
+        }
 
         KEY(site, protocol_string, @"protocol");
         KEY(site, url_queries, @"queries");
@@ -335,9 +350,6 @@ typedef NS_ENUM(NSInteger, Type) {
 
         dbProtocol *protocol = [dbProtocol dbGetByName:protocol_string];
 
-        BOOL enabledBool = NO;
-        if ([enabled isEqualToString:@"YES"] == YES)
-            enabledBool = YES;
 
         dbAccount *a = [dbAccount dbGetBySite:_site];
         if (a == nil) {

--- a/Geocube/GCBase/KeyManager.m
+++ b/Geocube/GCBase/KeyManager.m
@@ -50,6 +50,10 @@
 - (NSString *)decrypt:(NSString *)key data:(NSString *)encryptedString
 {
     NSString *password = [keyManager sharedSecret:key];
+    if (password == nil) {
+        NSLog(@"No password for %@, skipping decrypt", key);
+        return nil;
+    }
     NSError *error = nil;
     NSData *encryptedData = [[NSData alloc] initWithBase64EncodedString:encryptedString options:0];
     NSData *decryptedData = [RNDecryptor decryptData:encryptedData withPassword:password error:&error];


### PR DESCRIPTION
… aren’t present

The program crashes when importing if not all the appropriate authorization keys are present — but they aren’t supplied as part of the GitHub fork, and there isn’t any documentation on what keys are needed.

This set of changes at least keeps the program from crashing, so that the import will work and a new developer can get something working.


To reproduce this program:
* remove any Geocube executable on the device or simulator.
* create an empty EncryptionKeys.plist file -- or at least one without any "secret keys".
* build & run the program. When the dialog appears, select Import.
* the program will crash when it tries to process some of the import stuff. A new developer
can't get past this stage, and there isn't documentation clearly stating what secret keys are needed.

This fix just disables accounts for which there aren't appropriate secret keys. That allows a developer to get some things running.

There may be other ways of fixing this (such as removing the stuff that actually lists which accounts should be used, but this seemed like an easier way to get developers up and running.