### PR TITLE
Change display date format to better match date picker

### DIFF
--- a/Geocube/Filters/FilterDateTableViewCell.m
+++ b/Geocube/Filters/FilterDateTableViewCell.m
@@ -208,10 +208,8 @@
 
 - (void)dateWasSelected:(NSDate *)date element:(UIButton *)b
 {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"YYYY-MM-dd"];
-    NSString *dateFromString = [dateFormatter stringFromDate:date];
-
+    NSString *dateFromString = [NSDateFormatter localizedStringFromDate:date dateStyle:NSDateFormatterMediumStyle timeStyle:NSDateFormatterNoStyle];
+    
     [b setTitle:dateFromString forState:UIControlStateNormal];
 
     if (b == buttonDateLastLog)


### PR DESCRIPTION
The date picker uses words for month, and is in a localized order (month-day-year for US, day-month-year for other areas). The previous date display (2017-12-31) doesn’t match ever match the date picker (since it uses a month number).

I think it’s cleaner to use a more similar format for both the display and the date picker.