### PR TITLE
Fix bug where table cells weren't removing selection highlight

### DIFF
--- a/Geocube/GCBaseObjects/GCTableViewCellSwitch.xib
+++ b/Geocube/GCBaseObjects/GCTableViewCellSwitch.xib
@@ -12,7 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="GCTableViewCellSwitch">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="KGk-i7-Jjw" customClass="GCTableViewCellSwitch">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/Geocube/GCBaseObjects/GCTableViewCellSwitch~ipad.xib
+++ b/Geocube/GCBaseObjects/GCTableViewCellSwitch~ipad.xib
@@ -12,7 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="zpy-9a-rTa" customClass="GCTableViewCellSwitch">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="zpy-9a-rTa" customClass="GCTableViewCellSwitch">
             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zpy-9a-rTa" id="O9i-y6-XYc">

--- a/Geocube/Settings/SettingsMainViewController.m
+++ b/Geocube/Settings/SettingsMainViewController.m
@@ -1101,7 +1101,7 @@ enum sections {
                     [self changeThemeOrientations];
                     break;
             }
-            return;
+            break;
         case SECTION_APPS:
             switch (indexPath.row) {
                 case SECTION_APPS_EXTERNALMAP:
@@ -1111,7 +1111,7 @@ enum sections {
                     [self changeOpenCageKey];
                     break;
             }
-            return;
+            break;
         case SECTION_MAPSEARCHMAXIMUM:
             switch (indexPath.row) {
                 case SECTION_MAPSEARCHMAXIMUM_DISTANCE_GS:
@@ -1127,14 +1127,14 @@ enum sections {
                     [self changeMapSearchMaximumNumberGCA];
                     break;
             }
-            return;
+            break;
         case SECTION_MAPS:
             switch (indexPath.row) {
                 case SECTION_MAPS_DEFAULTBRAND:
                     [self changeMapsDefaultBrand];
                     break;
             }
-            return;
+            break;
         case SECTION_DYNAMICMAP:
             switch (indexPath.row) {
                 case SECTION_DYNAMICMAP_SPEED_WALKING:
@@ -1148,7 +1148,7 @@ enum sections {
                     [self changeDynamicmapDistance:indexPath.row];
                     break;
             }
-            return;
+            break;
         case SECTION_MAPCOLOURS:
             switch (indexPath.row) {
                 case SECTION_MAPCOLOURS_TRACK: {
@@ -1164,7 +1164,7 @@ enum sections {
                     break;
                 }
             }
-            return;
+            break;
 
         case SECTION_MAPCACHE:
             switch (indexPath.row) {
@@ -1175,7 +1175,7 @@ enum sections {
                     [self changeMapCacheMaxSize];
                     break;
             }
-            return;
+            break;
 
         case SECTION_IMPORTS:
             switch (indexPath.row) {
@@ -1186,7 +1186,7 @@ enum sections {
                     [self changeImportsQueryTimeout];
                     break;
             }
-            return;
+            break;
 
         case SECTION_KEEPTRACK:
             switch (indexPath.row) {
@@ -1199,7 +1199,7 @@ enum sections {
                     [self keeptrackChange:indexPath.row];
                     break;
             }
-            return;
+            break;
 
         case SECTION_WAYPOINTS:
             switch (indexPath.row) {
@@ -1207,7 +1207,7 @@ enum sections {
                     [self changeWaypointSortBy];
                     break;
             }
-            return;
+            break;
 
         case SECTION_LISTS:
             switch (indexPath.row) {
@@ -1215,7 +1215,7 @@ enum sections {
                     [self changeListSortBy];
                     break;
             }
-            return;
+            break;
 
         case SECTION_LOCATIONLESS:
             switch (indexPath.row) {
@@ -1223,7 +1223,7 @@ enum sections {
                     [self changeLocationlessSortOrder];
                     break;
             }
-            return;
+            break;
 
         case SECTION_BACKUPS:
             switch (indexPath.row) {
@@ -1234,8 +1234,9 @@ enum sections {
                     [self changeBackupsInterval];
                     break;
             }
-            return;
+            break;
     }
+    [aTableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
 /* ********************************************************************************* */


### PR DESCRIPTION
1) In tableView:didSelectRowAtIndexPath, it is necessary to call deselectRowAtIndexPath to clear the selection highlight.
2) Changed XIB files for table cells with switches so that they never show highlight.


How to reproduce the original problem:
1) go to the Settings->Settings page
2) Select any tableView row that has a switch (such as "Use metric units"). The row is visibly highlighted.
3) The row incorrectly remains highlighted. The correct UI behavior for tableView rows is that the highlight will go away.

Also:
1) go to the Settings->Settings page
2) select just about any row that brings up a dialog. The row is visibly highlighted.
3) cancel the dialog so that no changes are made. The row incorrectly remains highlighted.