### PR TITLE
Not really a pull request! Something for you to look at & discuss

### DIFF
--- a/Geocube.xcodeproj/project.pbxproj
+++ b/Geocube.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04C2C1A11F5742A300F8F8B8 /* GCTableViewCellPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 04C2C1A01F5742A300F8F8B8 /* GCTableViewCellPicker.m */; };
+		04C2C1A31F57442200F8F8B8 /* GCTableViewCellPicker.xib in Resources */ = {isa = PBXBuildFile; fileRef = 04C2C1A21F57442200F8F8B8 /* GCTableViewCellPicker.xib */; };
 		E804139D1E9EFF6D001FD7BF /* GC - logo - 512x512.png in Resources */ = {isa = PBXBuildFile; fileRef = E804139C1E9EFF6D001FD7BF /* GC - logo - 512x512.png */; };
 		E804139F1E9F984E001FD7BF /* Menu - 640x623.png in Resources */ = {isa = PBXBuildFile; fileRef = E804139E1E9F984E001FD7BF /* Menu - 640x623.png */; };
 		E80732FB1B633A74007FDC29 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E80732FA1B633A74007FDC29 /* main.m */; };
@@ -750,6 +752,9 @@
 
 /* Begin PBXFileReference section */
 		0087F95E865F48AD94ADB39B /* Pods-Geocube.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Geocube.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Geocube/Pods-Geocube.debug.xcconfig"; sourceTree = "<group>"; };
+		04C2C19F1F5742A300F8F8B8 /* GCTableViewCellPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GCTableViewCellPicker.h; path = GCBaseObjects/GCTableViewCellPicker.h; sourceTree = "<group>"; };
+		04C2C1A01F5742A300F8F8B8 /* GCTableViewCellPicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GCTableViewCellPicker.m; path = GCBaseObjects/GCTableViewCellPicker.m; sourceTree = "<group>"; };
+		04C2C1A21F57442200F8F8B8 /* GCTableViewCellPicker.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = GCTableViewCellPicker.xib; path = GCBaseObjects/GCTableViewCellPicker.xib; sourceTree = "<group>"; };
 		237ED37D295689D607775605 /* Pods-Geocube.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Geocube.release.xcconfig"; path = "Pods/Target Support Files/Pods-Geocube/Pods-Geocube.release.xcconfig"; sourceTree = "<group>"; };
 		88880BCD488967D0BA49FBE0 /* libPods-Geocube.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Geocube.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E804139C1E9EFF6D001FD7BF /* GC - logo - 512x512.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "GC - logo - 512x512.png"; path = "images/introduction/GC - logo - 512x512.png"; sourceTree = "<group>"; };
@@ -2496,6 +2501,9 @@
 				E82344EE1EECE12A00D2CDFD /* GCView.m */,
 				E82344EF1EECE12A00D2CDFD /* GCViewController.h */,
 				E82344F01EECE12A00D2CDFD /* GCViewController.m */,
+				04C2C19F1F5742A300F8F8B8 /* GCTableViewCellPicker.h */,
+				04C2C1A01F5742A300F8F8B8 /* GCTableViewCellPicker.m */,
+				04C2C1A21F57442200F8F8B8 /* GCTableViewCellPicker.xib */,
 			);
 			name = "Base GUI objects";
 			sourceTree = "<group>";
@@ -3835,6 +3843,7 @@
 				E82E66E81DA07CBE00CFBDED /* cache - whereigo - 30x30@3x.png in Resources */,
 				E82E667D1DA07C6F00CFBDED /* compass - red arrow on black.png in Resources */,
 				E82E66D51DA07CBE00CFBDED /* cache - traditional - 30x30.png in Resources */,
+				04C2C1A31F57442200F8F8B8 /* GCTableViewCellPicker.xib in Resources */,
 				E88DB00C1F334E4300FEF795 /* cache - gadget - 30x30@3.png in Resources */,
 				E82E66051DA079E500CFBDED /* log - published - 30x30.png in Resources */,
 				E823420C1EECCEEE00D2CDFD /* MHTabBarActiveTab.png in Resources */,
@@ -4315,6 +4324,7 @@
 				E82342C51EECD0B100D2CDFD /* dbProtocol.m in Sources */,
 				E82343F61EECDF4400D2CDFD /* WaypointHintViewController.m in Sources */,
 				E80D7EE51EFBE15700E25581 /* dbExternalMapURL.m in Sources */,
+				04C2C1A11F5742A300F8F8B8 /* GCTableViewCellPicker.m in Sources */,
 				E82344821EECE09C00D2CDFD /* ListIgnoredViewController.m in Sources */,
 				E823442E1EECDFB300D2CDFD /* FilterGroupsTableViewCell.m in Sources */,
 				E823444F1EECE04B00D2CDFD /* NotesSavedViewController.m in Sources */,

--- a/Geocube/GCBaseObjects/GCTableViewCellPicker.h
+++ b/Geocube/GCBaseObjects/GCTableViewCellPicker.h
@@ -1,0 +1,15 @@
+//
+//  GCTableViewCellPicker.h
+//  Geocube
+//
+//  Created by Tim Learmont on 8/30/17.
+//  Copyright © 2017 Edwin Groothuis. All rights reserved.
+//
+
+#define XIB_GCTABLEVIEWCELLPICKER @"GCTableViewCellPicker"
+
+@interface GCTableViewCellPicker : GCTableViewCell
+
+@property (nonatomic, weak) IBOutlet UIPickerView *pickerView;
+
+@end

--- a/Geocube/GCBaseObjects/GCTableViewCellPicker.m
+++ b/Geocube/GCBaseObjects/GCTableViewCellPicker.m
@@ -1,0 +1,29 @@
+//
+//  GCTableViewCellPicker.m
+//  Geocube
+//
+//  Created by Tim Learmont on 8/30/17.
+//  Copyright © 2017 Edwin Groothuis. All rights reserved.
+//
+
+#import "GCTableViewCellPicker.h"
+
+@interface GCTableViewCellPicker ()
+
+@end
+
+@implementation GCTableViewCellPicker
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    [self changeTheme];
+}
+
+- (void)changeTheme
+{
+    [super changeTheme];
+    // What to do to change picker theme
+}
+
+
+@end

--- a/Geocube/GCBaseObjects/GCTableViewCellPicker.xib
+++ b/Geocube/GCBaseObjects/GCTableViewCellPicker.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="416" id="UEB-Ga-nkD" customClass="GCTableViewCellPicker">
+            <rect key="frame" x="0.0" y="0.0" width="566" height="416"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="UEB-Ga-nkD" id="YeA-sO-mkV">
+                <rect key="frame" x="0.0" y="0.0" width="566" height="415.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aPa-ik-Hj2">
+                        <rect key="frame" x="0.0" y="0.0" width="566" height="415"/>
+                    </pickerView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="aPa-ik-Hj2" firstAttribute="centerY" secondItem="YeA-sO-mkV" secondAttribute="centerY" id="Aks-yH-c7C"/>
+                    <constraint firstItem="aPa-ik-Hj2" firstAttribute="width" secondItem="YeA-sO-mkV" secondAttribute="width" id="Pki-WT-YkA"/>
+                    <constraint firstItem="aPa-ik-Hj2" firstAttribute="height" secondItem="YeA-sO-mkV" secondAttribute="height" id="SVS-of-Dyc"/>
+                    <constraint firstItem="aPa-ik-Hj2" firstAttribute="centerX" secondItem="YeA-sO-mkV" secondAttribute="centerX" id="Uj2-oE-MNO"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="pickerView" destination="aPa-ik-Hj2" id="g65-RO-b9g"/>
+            </connections>
+            <point key="canvasLocation" x="123" y="40"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Geocube/Geocube-Prefix.pch
+++ b/Geocube/Geocube-Prefix.pch
@@ -145,6 +145,7 @@
 #import "GCScrollView.h"
 #import "GCSwitch.h"
 #import "GCTableViewCell.h"
+#import "GCTableViewCellPicker.h"
 #import "GCTableViewCellRightImage.h"
 #import "GCTableViewCellRightImageDisclosure.h"
 #import "GCTableViewCellSubtitleRightImage.h"


### PR DESCRIPTION
I was doing some looking at the whole UIPopoverController stuff, and I realized that most (all?) of the ActionSheet stuff is actually editing values in a tableview. I thought that I would play around with the idea of adding an extra table row for editing a value, similar to what the Calendar app does these days when setting times for events.

So, I quickly did up this branch. I hope that you'll download the code & run it and see if you think that this change to the UI is reasonable. If so, then I'll spend more time and actually do it nicely and clean stuff up a bunch. This was just a quick and dirty way to try out some things. [Note that it doesn't handle changing to the dark theme, for example]

The "default maps" picker, and the pickers for map search maximums use the new style of bringing up a picker in the row immediately following the info row. You can compare it with the pickers for the theme items to see how it compares. Notice that if you have a "orientations allowed" scrolled near the bottom of the screen, then the action sheet that appears covers over the row. However, with the new style, since a new row is inserted after the row you're affecting, that never happens and I think it's a bit more clear what the context is for the info you're changing. 