### PR TITLE
If there's only one account, just set that to make it easier for the …

### DIFF
--- a/Geocube/Waypoints/WaypointAddViewController.m
+++ b/Geocube/Waypoints/WaypointAddViewController.m
@@ -72,6 +72,27 @@ enum {
     [self.tableView registerClass:[GCTableViewCellWithSubtitle class] forCellReuseIdentifier:XIB_GCTABLEVIEWCELLWITHSUBTITLE];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    
+    if (account == nil) {
+        // The user hasn't set an account. If there is only one account with a name, then
+        // choose that.
+        [[dbc Accounts] enumerateObjectsUsingBlock:^(dbAccount *a, NSUInteger idx, BOOL *stop) {
+            if (IS_EMPTY(a.accountname.name) == YES)
+                return;
+            if (account == nil) {
+                account = a;
+            } else {
+                // There was another account, so reset account to nil and stop.
+                account = nil;
+                *stop = YES;
+            }
+        }];
+        
+    }
+}
 #pragma mark - TableViewController related functions
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)aTableView

--- a/Geocube/Waypoints/WaypointAddViewController.m
+++ b/Geocube/Waypoints/WaypointAddViewController.m
@@ -79,7 +79,7 @@ enum {
     if (account == nil) {
         // The user hasn't set an account. If there is only one account with a name, then
         // choose that.
-        [[dbc Accounts] enumerateObjectsUsingBlock:^(dbAccount *a, NSUInteger idx, BOOL *stop) {
+        [[dbc Accounts] enumerateObjectsUsingBlock:^(dbAccount * _Nonnull a, NSUInteger idx, BOOL * _Nonnull stop) {
             if (IS_EMPTY(a.accountname.name) == YES)
                 return;
             if (account == nil) {
@@ -90,7 +90,6 @@ enum {
                 *stop = YES;
             }
         }];
-        
     }
 }
 #pragma mark - TableViewController related functions


### PR DESCRIPTION
…user.

When you go to add a manual waypoint, the controller makes you choose which account. If the user only has one account, this is an unnecessary step. So, I added some code in viewWillAppear to set the account if none has been set and there is really only one choice.

You might prefer this in viewDidLoad, but I thought that viewWillAppear was more logical, especially if the view happens to get loaded some time way before it is displayed. That probably never happens now, but in the future, someone might decide to cache view controllers rather than recreating them each time, and viewWillAppear would make more sense then.