### PR TITLE
Have the definition of SecRandomCopyBytes match!

### DIFF
--- a/ContribLibrary/ContribLibrary/RNCryptor/RNCryptor.m
+++ b/ContribLibrary/ContribLibrary/RNCryptor/RNCryptor.m
@@ -58,7 +58,7 @@ const RNCryptorSettings kRNCryptorAES256Settings = {
     }
 };
 
-extern int SecRandomCopyBytes(SecRandomRef __nullable rnd, size_t count, uint8_t *bytes) __attribute__((weak_import));
+extern int SecRandomCopyBytes(SecRandomRef __nullable rnd, size_t count, void *bytes) __attribute__((weak_import));
 extern int
 CCKeyDerivationPBKDF( CCPBKDFAlgorithm algorithm, const char *password, size_t passwordLen,
                      const uint8_t *salt, size_t saltLen,


### PR DESCRIPTION
I'm not sure what version of XCode you're using, but when I try to compile the current Master, the code won't compile because SecRandomCopyBytes has a mismatched definition.

In one place, SecRandomCopyBytes was defined to take a void *, and in another place to take a uint8_t*. The compiler was complaining and so this code wouldn’t compile.

I changed the definition to match the Apple definition (although now if the Apple version isn’t available, it will still call it’s own version which has uint8_t* as the expected argument type, but I don’t think that is ia problem).