### PR TITLE
Create UI tests

### DIFF
--- a/Geocube.xcodeproj/project.pbxproj
+++ b/Geocube.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		044933CB1F748525006B38EC /* SimpleCoverageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044933CA1F748525006B38EC /* SimpleCoverageTest.swift */; };
 		E804139D1E9EFF6D001FD7BF /* GC - logo - 512x512.png in Resources */ = {isa = PBXBuildFile; fileRef = E804139C1E9EFF6D001FD7BF /* GC - logo - 512x512.png */; };
 		E804139F1E9F984E001FD7BF /* Menu - 640x623.png in Resources */ = {isa = PBXBuildFile; fileRef = E804139E1E9F984E001FD7BF /* Menu - 640x623.png */; };
 		E80732FB1B633A74007FDC29 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E80732FA1B633A74007FDC29 /* main.m */; };
@@ -552,6 +553,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		044933C51F7484F6006B38EC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E8F5704B1B3F7255003F020C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E8F570521B3F7255003F020C;
+			remoteInfo = Geocube;
+		};
 		E80CD3741F6F6175000AA10C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E881CA651F6B9F9600A17060 /* ToolsLibrary.xcodeproj */;
@@ -710,6 +718,9 @@
 
 /* Begin PBXFileReference section */
 		0087F95E865F48AD94ADB39B /* Pods-Geocube.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Geocube.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Geocube/Pods-Geocube.debug.xcconfig"; sourceTree = "<group>"; };
+		044933C01F7484F6006B38EC /* GeocubeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GeocubeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		044933C41F7484F6006B38EC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		044933CA1F748525006B38EC /* SimpleCoverageTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleCoverageTest.swift; sourceTree = "<group>"; };
 		237ED37D295689D607775605 /* Pods-Geocube.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Geocube.release.xcconfig"; path = "Pods/Target Support Files/Pods-Geocube/Pods-Geocube.release.xcconfig"; sourceTree = "<group>"; };
 		88880BCD488967D0BA49FBE0 /* libPods-Geocube.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Geocube.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E804139C1E9EFF6D001FD7BF /* GC - logo - 512x512.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "GC - logo - 512x512.png"; path = "images/introduction/GC - logo - 512x512.png"; sourceTree = "<group>"; };
@@ -1387,6 +1398,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		044933BD1F7484F6006B38EC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E80732F51B633A74007FDC29 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1436,6 +1454,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		044933C11F7484F6006B38EC /* GeocubeUITests */ = {
+			isa = PBXGroup;
+			children = (
+				044933CA1F748525006B38EC /* SimpleCoverageTest.swift */,
+				044933C41F7484F6006B38EC /* Info.plist */,
+			);
+			path = GeocubeUITests;
+			sourceTree = "<group>";
+		};
 		6917C4AD2B052674BDDB3A0D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -2600,6 +2627,7 @@
 				E881CA651F6B9F9600A17060 /* ToolsLibrary.xcodeproj */,
 				E8F570551B3F7255003F020C /* Geocube */,
 				E80732F91B633A74007FDC29 /* objects */,
+				044933C11F7484F6006B38EC /* GeocubeUITests */,
 				E8F570541B3F7255003F020C /* Products */,
 				6917C4AD2B052674BDDB3A0D /* Frameworks */,
 				E8F570B91B3FF668003F020C /* System Libraries */,
@@ -2614,6 +2642,7 @@
 				E8F5706C1B3F7255003F020C /* GeocubeTests.xctest */,
 				E80732F81B633A74007FDC29 /* objects */,
 				E8E8CFF11B64FAC900CC741A /* tests */,
+				044933C01F7484F6006B38EC /* GeocubeUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2720,6 +2749,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		044933BF1F7484F6006B38EC /* GeocubeUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 044933C91F7484F6006B38EC /* Build configuration list for PBXNativeTarget "GeocubeUITests" */;
+			buildPhases = (
+				044933BC1F7484F6006B38EC /* Sources */,
+				044933BD1F7484F6006B38EC /* Frameworks */,
+				044933BE1F7484F6006B38EC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				044933C61F7484F6006B38EC /* PBXTargetDependency */,
+			);
+			name = GeocubeUITests;
+			productName = GeocubeUITests;
+			productReference = 044933C01F7484F6006B38EC /* GeocubeUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		E80732F71B633A74007FDC29 /* objects */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E80732FC1B633A74007FDC29 /* Build configuration list for PBXNativeTarget "objects" */;
@@ -2807,9 +2854,16 @@
 		E8F5704B1B3F7255003F020C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Edwin Groothuis";
 				TargetAttributes = {
+					044933BF1F7484F6006B38EC = {
+						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
+						TestTargetID = E8F570521B3F7255003F020C;
+					};
 					E80732F71B633A74007FDC29 = {
 						CreatedOnToolsVersion = 6.4;
 					};
@@ -2895,6 +2949,7 @@
 				E8F5706B1B3F7255003F020C /* GeocubeTests */,
 				E80732F71B633A74007FDC29 /* objects */,
 				E8E8CFF01B64FAC900CC741A /* tests */,
+				044933BF1F7484F6006B38EC /* GeocubeUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -2966,6 +3021,13 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		044933BE1F7484F6006B38EC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E8F570511B3F7255003F020C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3441,6 +3503,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		044933BC1F7484F6006B38EC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				044933CB1F748525006B38EC /* SimpleCoverageTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E80732F41B633A74007FDC29 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3586,6 +3656,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		044933C61F7484F6006B38EC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E8F570521B3F7255003F020C /* Geocube */;
+			targetProxy = 044933C51F7484F6006B38EC /* PBXContainerItemProxy */;
+		};
 		E831D69D1F6F9BBD005D3ECA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BaseObjectsLibrary;
@@ -3650,6 +3725,68 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		044933C71F7484F6006B38EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = GeocubeUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.mavetju.GeocubeUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Geocube;
+			};
+			name = Debug;
+		};
+		044933C81F7484F6006B38EC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = GeocubeUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.mavetju.GeocubeUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Geocube;
+			};
+			name = Release;
+		};
 		E80732FD1B633A74007FDC29 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3931,6 +4068,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		044933C91F7484F6006B38EC /* Build configuration list for PBXNativeTarget "GeocubeUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				044933C71F7484F6006B38EC /* Debug */,
+				044933C81F7484F6006B38EC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E80732FC1B633A74007FDC29 /* Build configuration list for PBXNativeTarget "objects" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/GeocubeUITests/Info.plist
+++ b/GeocubeUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/GeocubeUITests/SimpleCoverageTest.swift
+++ b/GeocubeUITests/SimpleCoverageTest.swift
@@ -1,0 +1,145 @@
+//
+//  SimpleCoverageTest.swift
+//  GeocubeUITests
+//
+//  Created by Tim Learmont on 9/20/17.
+//  Copyright © 2017 Edwin Groothuis. All rights reserved.
+//
+
+import XCTest
+
+class SimpleCoverageTest: XCTestCase {
+    typealias ScreenTest = (screenName:String, hasLocalMenu:Bool)
+    typealias CommandTest = (command:String, swipeUpFrom: String?, screens:[ScreenTest])
+
+    override func setUp() {
+        super.setUp()
+        
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        XCUIApplication().launch()
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func coverageTestHelper(tests coverageTests: [CommandTest]) {
+        let app = XCUIApplication()
+        
+        // XXX These tests should be re-written using Accessibility IDs so they don't depend on language.
+        let menuIconGlobalDefaultButton = app.buttons["menu icon   global   default"]
+        let localMenuButton = app.buttons["menu icon   local   default"]
+        
+        
+        let tablesQuery = app.tables
+        
+        for (command, swipeUpFrom, screens) in coverageTests {
+            menuIconGlobalDefaultButton.tap()
+            if let swipeUpCommand = swipeUpFrom {
+                tablesQuery.staticTexts[swipeUpCommand].swipeUp()
+            }
+            let currentCommandElement = tablesQuery.staticTexts[command]
+            if currentCommandElement.exists {
+                currentCommandElement.tap()
+                
+                if let (lastScreen, _) = screens.last {
+                    // Select the last screen
+                    app.buttons[lastScreen].tap()
+                }
+                // Now, go through all the screens and make sure that they work.
+                for (screenName, hasLocalMenu) in screens {
+                    app.buttons[screenName].tap()
+                    if hasLocalMenu != localMenuButton.exists {
+                        // It either is supposed to have a local menu and doesn't or vice versa.
+                        // Show an appropriate message.
+                        if hasLocalMenu {
+                            XCTFail("\(command)/\(screenName) should have a local menu but doesn't")
+                        } else {
+                            XCTFail("\(command)/\(screenName) should not have a local menu, but does")
+                        }
+                    } else if localMenuButton.exists {
+                        // Try tapping it and then making it go away.
+                        localMenuButton.tap()
+                        // Now, make the local menu go away.
+                        menuIconGlobalDefaultButton.tap()
+                        
+                    }
+                }
+                
+            } else {
+                XCTFail("Could not find global menu item \(command)")
+            }
+        }
+        
+    }
+
+    /// Test the expected items in the UI once a user has initialized the app.
+    func testCoverageExpected() {
+        let coverageTests:[CommandTest] = [
+            ("Navigate", nil, [("Compass", false), ("Target", true), ("Map", true)]),
+            ("Waypoints", nil, [("Filters", true), ("List", true), ("Map", true)]),
+            ("Keep Track", nil, [("Car", true), ("Tracks", true), ("Map", true), ("Beeper", false)]),
+            ("Notes + Logs", nil, [("Saved", true), ("Personal", false), ("Field", false), ("Images", false)]),
+            ("Groups", nil, [("User Groups", true), ("System Groups", false)]),
+            ("Lists", nil, [("Highlight", true), ("DNF", true), ("In Progress", true)]),
+            ("Queries", nil, [("Geocaching.com Website", true), ("GCA", true)]),
+            ("Trackables", nil, [("Inventory", true), ("Mine", true), ("List", false)]),
+            ("Locationless", nil, [("All", true), ("Planned", true), ("Map", true)]),
+            ("Files", nil, [("Local Files", true), ("KML", false), ("File Browser", false)]),
+            ("Statistics", nil, [("Statistics", true)]),
+            ("Browser", nil, [("User", true), ("Queries", false), ("Browser", true)]),
+            ("Tools", nil, [("GNSS", true), ("ROT13", false)]),
+            ("Settings", nil, [("Accounts", true), ("Settings", true), ("Colours", true), ("Log", true)]),
+            ("Help", "Settings", [("About", false), ("Help", true), ("Notices", true)])
+            ]
+            
+       
+        coverageTestHelper(tests: coverageTests)
+ 
+    }
+    
+    // Test that the "Initialize Notices alert goes away.
+    func testInitializeNoticesGoesAway() {
+        let app = XCUIApplication()
+        
+        // XXX These tests should be re-written using Accessibility IDs so they don't depend on language.
+        let menuIconGlobalDefaultButton = app.buttons["menu icon   global   default"]
+        menuIconGlobalDefaultButton.tap()
+        
+        let tablesQuery = app.tables
+        tablesQuery.staticTexts["Statistics"].swipeUp()
+        tablesQuery.staticTexts["Help"].tap()
+        
+        // Go to the notices page.
+        app.buttons["Notices"].tap()
+        if app.alerts["Initialize notices"].exists {
+            XCTFail("Clear notices and run test again.")
+            return
+        }
+        // Switch to another page.
+        app.buttons["About"].tap()
+        
+        // Now, go back to the notices page, and ensure that the notices alert doesn't recur
+        app.buttons["Notices"].tap()
+        if app.alerts["Initialize notices"].exists {
+            XCTFail("Error: notices shouldn't be requested again!")
+        }
+
+    }
+    // Test the developer stuff that might be removed from the shipping version.
+    func testCoverageDeveloper() {
+         let developerTests:[CommandTest] = [
+            ("Developer", "Trackables", [ ("Images", false), ("DB", true)])
+        ]
+        
+        coverageTestHelper(tests: developerTests)
+        
+    }
+}


### PR DESCRIPTION
When I try the 9/21 set of code, it appears that the Notices page doesn't work correctly. If you go to Help->Notices, it pops up an alert telling you to initialize notices. If you do that, it gives a success alert (successful download of revision 2). If you then switch to some other page (say "About"), and then back to Notices, it again pops up the alert saying that you need to initialize notices. I'm not sure what the real problem is -- whether the notices aren't appropriately saved, whether the notices aren't actually being downloaded correctly, or even whether NoticesViewController.viewDidAppear should check "[notices count] > 0" rather than ">1".

I thought that having some automated testing would be useful to document both bugs and provide regression testing to show that they are fixed. So, I created an initial set of UI tests.

The major tests just check coverage by going through every screen and checking that it can be displayed (and that it appropriately has a local menu). I added this test because when I use the Geocube available on iTunes now, if I go to the Locationless set of screens, the app crashes (because it tries to use tableview scrolling to row 0, but there aren't any rows). That kind of thing will be discovered by the simple coverage tests.

There is test for Notices being cleared. Initially, you should run the app and download notices if necessary. Then run the test, which will check that switching to the Notices screen doesn't make an alert show up.